### PR TITLE
Unlock redirectTo and onlyThirdPartyProviders

### DIFF
--- a/streamlit_supabase_auth/__init__.py
+++ b/streamlit_supabase_auth/__init__.py
@@ -47,6 +47,8 @@ def login_form(
     url: Optional[str] = None,
     apiKey: Optional[str] = None,
     providers: Optional[List[str]] = None,
+    redirectTo: Optional[str] = None,
+    onlyThirdPartyProviders: Optional[bool] = None,
 ) -> Mapping[str, Any]:
     """Creates a new instance of `login` component using supabase-js.
 
@@ -67,6 +69,8 @@ def login_form(
         apiKey=apiKey or os.environ["SUPABASE_KEY"],
         providers=providers or [],
         key="login",
+        redirectTo=redirectTo or None,
+        onlyThirdPartyProviders=onlyThirdPartyProviders or False,
     )
     # Modify the value returned so that it can be used as default selections.
     return session

--- a/streamlit_supabase_auth/frontend/package-lock.json
+++ b/streamlit_supabase_auth/frontend/package-lock.json
@@ -4950,9 +4950,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001660",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
+      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4961,6 +4961,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -24248,9 +24252,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
+      "version": "1.0.30001660",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
+      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/streamlit_supabase_auth/frontend/src/App.tsx
+++ b/streamlit_supabase_auth/frontend/src/App.tsx
@@ -99,8 +99,11 @@ const Container = (props: {
   type: "login" | "logout";
   supabase: SupabaseClient;
   providers: Provider[];
+  redirectTo?: string;
+  onlyThirdPartyProviders?: boolean;
 }) => {
-  const { type, supabase, providers } = props;
+  const { type, supabase, providers, redirectTo, onlyThirdPartyProviders } =
+    props;
 
   // Update iframe height when user context changes
   useEffect(() => Streamlit.setFrameHeight());
@@ -112,6 +115,8 @@ const Container = (props: {
         providers={providers}
         supabaseClient={supabase}
         onError={() => Streamlit.setFrameHeight()}
+        redirectTo={redirectTo}
+        onlyThirdPartyProviders={onlyThirdPartyProviders}
       />
     );
   }
@@ -128,7 +133,8 @@ const Container = (props: {
 };
 
 const App = (props: ComponentProps) => {
-  const { url, apiKey, providers, key } = props.args;
+  const { url, apiKey, providers, key, redirectTo, onlyThirdPartyProviders } =
+    props.args;
 
   // Initialise supabase client once
   const [supabase, setSupabase] = useState<SupabaseClient>(() =>
@@ -154,7 +160,13 @@ const App = (props: ComponentProps) => {
 
   return (
     <Auth.UserContextProvider supabaseClient={supabase}>
-      <Container type={key} supabase={supabase} providers={providers} />
+      <Container
+        type={key}
+        supabase={supabase}
+        providers={providers}
+        redirectTo={redirectTo}
+        onlyThirdPartyProviders={onlyThirdPartyProviders}
+      />
     </Auth.UserContextProvider>
   );
 };

--- a/streamlit_supabase_auth/frontend/src/Auth/Auth.tsx
+++ b/streamlit_supabase_auth/frontend/src/Auth/Auth.tsx
@@ -219,6 +219,8 @@ function SocialAuth({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [error, setError] = useState("");
 
+  console.log({ redirectTo });
+
   const handleProviderSignIn = async (provider: Provider) => {
     setLoading(true);
     try {


### PR DESCRIPTION
There are no options, "redirectTo" and "onlyThirdPartyProviders" in the function `login_form` in spite of the implementations in the react codes. These options have been added.